### PR TITLE
don't use path for URL construction

### DIFF
--- a/lib/plugin.js
+++ b/lib/plugin.js
@@ -687,7 +687,7 @@ exports.register = function (plugin, opts, next) {
     // hapi wont find the local swig without this
     plugin.expose(api);
     plugin.route({ method: 'get', path: settings.relsPath, config: internals.namespacesRoute(settings.relsAuth) });
-    plugin.route({ method: 'get', path: path.join(settings.relsPath, '{namespace}/{rel}'), config: internals.relRoute(settings.relsAuth) });
+    plugin.route({ method: 'get', path: settings.relsPath + '/{namespace}/{rel}'), config: internals.relRoute(settings.relsAuth) });
 
     selection.ext('onPreResponse', internals.preResponse.bind(internals, api, settings));
 


### PR DESCRIPTION
path.join() uses \ instead of / and causes a hapi exception on windows

closes #39 
