### PR TITLE
Fixes broken search when absolute href is generated from location header

### DIFF
--- a/lib/plugin.js
+++ b/lib/plugin.js
@@ -526,13 +526,15 @@ internals.getMediaType = function (mediaTypes, request) {
  * Expands the url path to include protocol://server:port
  * @param request
  * @param path
+ * @param search
  * @return {*}
  */
-internals.expandPath = function(request, path) {
+internals.expandPath = function(request, path, search) {
     return  url.format({
         host: request.headers.host || request.connection.info.host,
         pathname: path,
-        protocol: request.connection.info.protocol
+        protocol: request.connection.info.protocol,
+        search: search
     });
 };
 
@@ -566,15 +568,20 @@ internals.location = function (request, uri, absolute) {
     var isAbsolute = (uri.match(/^\w+\:\/\//));
 
     var path = isAbsolute ? uri : (uri.charAt(0) === '/' ? '' : '/') + uri;
+    var search = null;
 
     if (isAbsolute) {
         path = uri;
     } else {
-        path = (uri.charAt(0) === '/' ? '' : '/') + uri;
+        var parts = uri.split('?');
+        path = (parts[0].charAt(0) === '/' ? '' : '/') + parts[0];
+        if (parts.length > 1) {
+            search = parts[1];
+        }
     }
 
     if (absolute) {
-        path = internals.expandPath(request, path);
+        path = internals.expandPath(request, path, search);
     }
     return path;
 };

--- a/package.json
+++ b/package.json
@@ -24,6 +24,7 @@
   "homepage": "https://github.com/bleupen/halacious",
   "devDependencies": {
     "chai": "^2.0.0",
+    "chai-string": "^1.1.1",
     "hapi": "^8.0.0",
     "mocha": "^2.1.0",
     "sinon": "^1.10.2",

--- a/test/plugin-spec.js
+++ b/test/plugin-spec.js
@@ -6,9 +6,11 @@ var plugin = require('../lib/plugin');
 var hapi = require('hapi');
 var sinon = require('sinon');
 var sinonChai = require('sinon-chai');
+var chaiString = require('chai-string');
 var halacious = require('../');
 var _ = require('lodash');
 chai.use(sinonChai);
+chai.use(chaiString);
 
 var hapiPlugin = {
     expose: sinon.spy()
@@ -958,6 +960,46 @@ describe('Halacious Plugin', function () {
                     firstName: 'Bob',
                     lastName: 'Smith'
                 });
+                done();
+            } catch (err) {
+                done(err);
+            }
+        });
+    });
+
+    it.only('use of location header for absolute link generation should not break url search', function (done) {
+        var server = new hapi.Server();
+        server.connection({ port: 9090 });
+        var result;
+
+        server.route({
+            method: 'post',
+            path: '/people',
+            config: {
+                handler: function (req, reply) {
+                    reply({ id: 100, firstName: 'Bob', lastName: 'Smith' }).created('/people/100?donotbreakthis=true');
+                }
+            }
+        });
+
+        server.register({
+            register:halacious,
+            options: {
+                absolute: true
+            }
+        }, function (err) {
+            if (err) return done(err);
+        });
+
+        server.inject({
+            method: 'post',
+            url: '/people',
+            headers: { Accept: 'application/hal+json' }
+        }, function (res) {
+            try {
+                res.statusCode.should.equal(201);
+                result = JSON.parse(res.payload);
+                result.should.have.a.property('_links').that.has.a.property('self').that.has.a.property('href').that.endsWith('/people/100?donotbreakthis=true');
                 done();
             } catch (err) {
                 done(err);

--- a/test/plugin-spec.js
+++ b/test/plugin-spec.js
@@ -967,7 +967,7 @@ describe('Halacious Plugin', function () {
         });
     });
 
-    it.only('use of location header for absolute link generation should not break url search', function (done) {
+    it('use of location header for absolute link generation should not break url search', function (done) {
         var server = new hapi.Server();
         server.connection({ port: 9090 });
         var result;


### PR DESCRIPTION
The enclosing test case shows that expandPath is breaking the search part of the relative URL it is trying to expand.