### PR TITLE
add required dev deps to run gulp test

### DIFF
--- a/package.json
+++ b/package.json
@@ -24,6 +24,7 @@
   "homepage": "https://github.com/bleupen/halacious",
   "devDependencies": {
     "chai": "^2.1.1",
+    "chai-string": "^1.1.2",
     "gulp": "^3.8.11",
     "gulp-bump": "^0.2.2",
     "gulp-filter": "^2.0.2",
@@ -32,8 +33,11 @@
     "gulp-jshint": "^1.9.2",
     "gulp-mocha": "^2.0.0",
     "gulp-tag-version": "^1.2.1",
+    "hapi": "^8.8.1",
     "jshint-stylish": "^1.0.1",
-    "mocha": "^2.2.1"
+    "mocha": "^2.2.1",
+    "sinon": "^1.15.4",
+    "sinon-chai": "^2.8.0"
   },
   "dependencies": {
     "hoek": "^2.3.0",


### PR DESCRIPTION
I couldn't run gulp test without installing a few more dependencies, figured maybe you'd not noticed?

Here's the dev deps I added to get gulp test to run clean. I kept Hapi@8.8.1 as it's the latest version that works - something looks like it's changed in 9.0.0 that breaks the server.views call in the plugin file. I'll add an issue to upgrade for Hapi 9.x separately.

Hope it helps, first time trying a pull request - more than happy to get criticism if I did anything wrong!

Cheers

Paul