### PR TITLE
Feature/embed array of embeddable objects

### DIFF
--- a/lib/representation.js
+++ b/lib/representation.js
@@ -186,10 +186,11 @@ Representation.prototype.embed = function(rel, selfOrEmbeddables, entity) {
     }
 
     if (_.isArray(entity)){
-        var that = this;
+        var that = this,
+            self = selfOrEmbeddables;
         this._embedded[qname] = [];
         return entity.map(function (e) {
-            return that.embed(originalRel, selfOrEmbeddables, e);
+            return that.embed(originalRel, self, e);
         }, this);
     }
 

--- a/lib/representation.js
+++ b/lib/representation.js
@@ -122,7 +122,7 @@ Representation.prototype.link = function(rel, link) {
             return that.link(originalRel, l);
         }, this);
     }
-    
+
     // adds the namespace to the top level curie list
     this.curie(rel.namespace);
 
@@ -161,13 +161,13 @@ Representation.prototype.route = function(routeName, params) {
 };
 
 /**
- * Wraps an entity into a HAL representation and adds it to the _embedded collection
+ * Wraps entities into a HAL representation and adds them to the _embedded collection.
  * @param {String} rel the rel name
- * @param {String || {}} self an href or link object for the entity
+ * @param {String || {} || []} self an href, a link object for the entity or an array of {self: link, entity: entityToEmbed}
  * @param {{} || []} entity an object to wrap
  * @return {entity || []}
  */
-Representation.prototype.embed = function(rel, self, entity) {
+Representation.prototype.embed = function(rel, selfOrEmbeddables, entity) {
     var qname;
     var originalRel = rel;
     rel = this._halacious.rel(rel);
@@ -175,17 +175,27 @@ Representation.prototype.embed = function(rel, self, entity) {
 
     this.curie(rel.namespace);
 
+    if (_.isArray(selfOrEmbeddables)) {
+        var that = this,
+            embeddables = selfOrEmbeddables;
+        this._embedded[qname] = [];
+        return embeddables.map(function (e) {
+            if (!e.self || !e.entity) return that;
+            return that.embed(originalRel, e.self, e.entity);
+        }, this);
+    }
+
     if (_.isArray(entity)){
         var that = this;
         this._embedded[qname] = [];
         return entity.map(function (e) {
-            return that.embed(originalRel, self, e);
+            return that.embed(originalRel, selfOrEmbeddables, e);
         }, this);
     }
 
-    self = this._halacious.link(self, this._links.self.href);
+    var selfLink = this._halacious.link(selfOrEmbeddables, this._links.self.href);
 
-    var embedded = this.factory.create(entity, self, this._root);
+    var embedded = this.factory.create(entity, selfLink, this._root);
 
     if (!this._embedded[qname]) {
         this._embedded[qname] = embedded;

--- a/package.json
+++ b/package.json
@@ -24,6 +24,7 @@
   "homepage": "https://github.com/bleupen/halacious",
   "devDependencies": {
     "chai": "^2.1.1",
+    "chai-string": "^1.1.2",
     "gulp": "^3.8.11",
     "gulp-bump": "^0.2.2",
     "gulp-filter": "^2.0.2",
@@ -32,8 +33,11 @@
     "gulp-jshint": "^1.9.2",
     "gulp-mocha": "^2.0.0",
     "gulp-tag-version": "^1.2.1",
+    "hapi": "^8.8.1",
     "jshint-stylish": "^1.0.1",
-    "mocha": "^2.2.1"
+    "mocha": "^2.2.1",
+    "sinon": "^1.15.4",
+    "sinon-chai": "^2.8.0"
   },
   "dependencies": {
     "hoek": "^2.3.0",

--- a/test/representation-spec.js
+++ b/test/representation-spec.js
@@ -47,7 +47,7 @@ describe('Representation Factory', function() {
         rep._links['mco:boss'][1].should.have.property('href', '/people/101');
         rep._links['mco:boss'][2].should.have.property('href', '/people/102');
     });
-    
+
     it('should create a single-element array of links', function () {
         var entity = {};
         var rep = rf.create(entity, '/people');
@@ -135,6 +135,21 @@ describe('Representation Factory', function() {
         var rep = rf.create({ firstName: 'Bob' }, '/people');
         rep.link('employees', []);
         rep._links.should.have.property('employees').that.has.length(0);
+    });
+
+    it('should not break when embedding an empty array', function () {
+        var rep = rf.create({ firstName: 'Bob' }, '/people');
+        rep.embed('employees', []);
+        rep._embedded.should.have.property('employees').that.has.length(0);
+    });
+
+    it('should embed an array of embeddable objects', function () {
+        var rep = rf.create({ firstName: 'Bob' }, '/people');
+        rep.embed('employees', [
+            {self: './1', name: 'John'},
+            {self: './2', name: 'Marian'}
+        ]);
+        rep._embedded.should.have.property('employees').that.has.length(0);
     });
 
     it('should resolve relative paths', function () {

--- a/test/representation-spec.js
+++ b/test/representation-spec.js
@@ -146,7 +146,22 @@ describe('Representation Factory', function() {
     it('should embed an array of embeddable objects', function () {
         var rep = rf.create({ firstName: 'Bob' }, '/people');
         rep.embed('employees', [
-            {self: './1', name: 'John'},
+            {self: './1', entity: {name: 'John'}},
+            {self: './2', entity: {name: 'Marian'}}
+        ]);
+
+        rep._embedded.should.have.property('employees').that.has.length(2);
+        var employees = rep._embedded.employees;
+        employees[0].should.have.property('self', '/people/1');
+        employees[0].should.have.property('entity').eql({name: 'John'});
+        employees[1].should.have.property('self', '/people/2');
+        employees[1].should.have.property('entity').eql({name: 'Marian'});
+    });
+
+    it('should skip embeddable objects that are incorrectly defined', function () {
+        var rep = rf.create({ firstName: 'Bob' }, '/people');
+        rep.embed('employees', [
+            {x: './1', entity: 'John'},
             {self: './2', name: 'Marian'}
         ]);
         rep._embedded.should.have.property('employees').that.has.length(0);


### PR DESCRIPTION
I'm not sure whether this is clean enough - I renamed the self arg to selfOrEmbeddables to try and express the dual purpose and then renamed it back in the two short-circuit array checks as appropriate.

I wonder whether a separate function - embedAll(rel, [....]) or some such - would be simpler and easier (with corresponding linkAll(rel, [...]). Also would make documentation a bit easier too?

If you're happy then great - if not, totally understand - can have a go at that ...All idea if you think that's better. 

(This is build on my other PR with the gulp deps)