### PR TITLE
Allow empty apiPath in plugin options

### DIFF
--- a/lib/plugin.js
+++ b/lib/plugin.js
@@ -60,7 +60,7 @@ var optionsSchema = {
     relsPath: joi.string().default('/rels'),
     relsAuth: joi.alternatives().try(joi.boolean().allow(false),joi.object()).default(false),
     autoApi: joi.boolean().default(true),
-    apiPath: joi.string().default('/api'),
+    apiPath: joi.string().allow('').default('/api'),
     apiAuth: joi.alternatives().try(joi.boolean().allow(false),joi.object()).default(false),
     apiServerLabel: joi.string(),
     mediaTypes: joi.array().includes(joi.string()).single().default(['application/hal+json'])


### PR DESCRIPTION
Not sure since when, but the newer version of Joi (halacious uses joi@^5.0.0) doesn't allow empty strings when just specifying `joi.string()`. To allow empty strings, `joi.string()` must be appended with `.allow('')`.

(Joi docs: https://github.com/hapijs/joi/blob/master/API.md#string)