### PR TITLE
enabled HALification for all the success status codes (2xx)

### DIFF
--- a/lib/plugin.js
+++ b/lib/plugin.js
@@ -640,7 +640,7 @@ exports.register = function (server, opts, next) {
     };
 
     internals.successfulResponseCode = function (statusCode) {
-        return statusCode === 200 || statusCode === 201;
+        return statusCode >= 200 && statusCode < 300;
     };
 
     internals.isSourceEligible = function (source) {


### PR DESCRIPTION
Hi.
I have some 206 codes in my app that should be halified.
I thought it was a good idea to authorize all the 2xx possible status codes. What do you think?