### PR TITLE
HALify only  when negotiating a HAL mediaType

### DIFF
--- a/lib/plugin.js
+++ b/lib/plugin.js
@@ -64,7 +64,8 @@ var optionsSchema = {
     apiPath: joi.string().allow('').default('/api'),
     apiAuth: joi.alternatives().try(joi.boolean().allow(false),joi.object()).default(false),
     apiServerLabel: joi.string(),
-    mediaTypes: joi.array().includes(joi.string()).single().default(['application/hal+json'])
+    mediaTypes: joi.array().includes(joi.string()).single().default(['application/hal+json']),
+    defaultNonHalMediaType: joi.string()
 };
 
 /**
@@ -671,11 +672,15 @@ exports.register = function (server, opts, next) {
      * @param reply
      */
     internals.preResponse = function (halacious, settings, request, reply) {
-        var rf, halConfig, entity, rep, self, location;
-        var mediaType = internals.getMediaType(settings.mediaTypes, request);
-        var absolute;
+        var rf, halConfig, entity, rep, self, location, absolute;
+        
+        var allMediaTypes = _.clone(settings.mediaTypes);
+        if (settings.defaultNonHalMediaType) {
+          allMediaTypes.unshift(settings.defaultNonHalMediaType);
+        }
+        var mediaType = internals.getMediaType(allMediaTypes, request);
 
-        if (mediaType && internals.shouldHalify(request)) {
+        if (_.includes(settings.mediaTypes, mediaType) && internals.shouldHalify(request)) {
 
             halConfig = request.route.settings.plugins.hal || {};
 

--- a/package.json
+++ b/package.json
@@ -24,6 +24,7 @@
   "homepage": "https://github.com/bleupen/halacious",
   "devDependencies": {
     "chai": "^2.1.1",
+    "chai-string": "^1.1.4",
     "gulp": "^3.8.11",
     "gulp-bump": "^0.2.2",
     "gulp-filter": "^2.0.2",
@@ -35,6 +36,8 @@
     "hapi": "^11.0.0",
     "jshint-stylish": "^1.0.1",
     "mocha": "^2.2.1",
+    "sinon": "^1.17.2",
+    "sinon-chai": "^2.8.0",
     "vision": "^3.0.0"
   },
   "dependencies": {


### PR DESCRIPTION
_Hi. With this PR, I would like to discuss how to best handle the issue I have_

**halify only  when negotiating a HAL mediaType (but not another mediaType handled by the app)**

Here's my use-case:
[I have an app](https://github.com/boillodmanuel/rest-from-zero-to-hero) which handles `hal+json` and `json`. When returning json, the representation isn't wrapped with HAL. All is fine here.

My problem is that the app returns a hal+json representation by default (i.e with no accept header,which is equivalent to `accept: */*`). I'd have preferred json :/

Have I missed something?

If not, I tried to solve this issue with this PR in which:
* the end-user can provide a full list of the mediaTypes supported by his app.
* this list is given to Negotiator which finds the mediaType to use.
* No HALification occurs when it's not a "HAL mediaType"

Best,
Antoine