### PR TITLE
Modify the existing response object rather than returning a new one i…

### DIFF
--- a/lib/plugin.js
+++ b/lib/plugin.js
@@ -815,23 +815,10 @@ exports.register = function (server, opts, next) {
                 }
 
                 // send back what they asked for
-                var response = reply(rep)
-                    .type(mediaType)
-                    .code(request.response.statusCode);
+                request.response.source = rep
+                request.response.type(mediaType)
 
-                // avoid an undefined header
-                if (request.response.settings.location) response.location(request.response.settings.location);
-
-                response.hold();
-
-                // // copy headers
-                _.forEach(request.response.headers, function (value, key) {
-                    if (key !== 'content-type') {
-                        response.header(key, value);
-                    }
-                });
-
-                response.send();
+                reply.continue()
             });
         } else {
             reply.continue();


### PR DESCRIPTION
…n order to preserve api request lifecycle.

According to hapi documentation to keep the default lifecycle of a request intact the response object should not be replaced by a new one:
http://hapijs.com/api#serverextevents

I've modified the code to update the successful response with the new content instead.

Let me know if you think there's more that needs to be done on it.