### PR TITLE
handle presence of hapi optional modifiers in named route path parameters

### DIFF
--- a/lib/plugin.js
+++ b/lib/plugin.js
@@ -435,7 +435,7 @@ exports.register = function (server, opts, next) {
     internals.route = function (routeId, params) {
         var route = server.lookup(routeId) || internals.locateRoute(routeId);
         if (!route) throw new Error('No route found with id or name ' + routeId);
-        var href = _.template(route.path, { interpolate: /{([\s\S]+?)}/g })(_.mapValues(params, function(val) {
+        var href = _.template(route.path, { interpolate: /{([\s\S]+?)(?:\?|\*\d*)??}/g })(_.mapValues(params, function(val) {
             return typeof val !== 'object' ? encodeURIComponent(val) : val;
         }));
         var query = hoek.reach(route.settings, 'plugins.hal.query');

--- a/test/plugin-spec.js
+++ b/test/plugin-spec.js
@@ -340,7 +340,7 @@ describe('Halacious Plugin', function () {
         });
     });
 
-    it('should handle optional Hapi route parameters in a named route', function (done) {
+    it('should handle presence of optional Hapi route parameters in a named route', function (done) {
         var server = new hapi.Server();
         server.connection({ port: 9090 });
 

--- a/test/plugin-spec.js
+++ b/test/plugin-spec.js
@@ -81,10 +81,13 @@ describe('Halacious Plugin', function () {
         server.connection({ port: 9090 });
         server.register(halacious, function () {
             var plugin = server.plugins.halacious;
-            plugin.namespaces.add.bind(plugin.namespaces, { name: 'mycompany', prefirx: 'mco'}).should.throw('prefirx is not allowed');
+            plugin.namespaces.add.bind(plugin.namespaces, {
+                name: 'mycompany',
+                prefirx: 'mco'
+            }).should.throw('prefirx is not allowed');
         });
     });
-    
+
     it('should add a rel to a namespace', function (done) {
         var server = new hapi.Server();
         server.connection({ port: 9090 });
@@ -112,7 +115,7 @@ describe('Halacious Plugin', function () {
         });
     });
 
-    it('should remove a namespace', function() {
+    it('should remove a namespace', function () {
         var server = new hapi.Server();
         server.connection({ port: 9090 });
         server.register(halacious, function () {
@@ -160,7 +163,7 @@ describe('Halacious Plugin', function () {
         server.register(halacious, function () {
             var rels, plugin = server.plugins.halacious;
             plugin.namespaces.add({ name: 'mycompany', prefix: 'mco' }).rel('a_rel').rel('c_rel');
-            plugin.namespaces.add({ name: 'yourcompany', prefix: 'yco'}).rel('b_rel').rel('d_rel');
+            plugin.namespaces.add({ name: 'yourcompany', prefix: 'yco' }).rel('b_rel').rel('d_rel');
             rels = plugin.rels();
             rels.should.have.length(4);
             _.pluck(rels, 'name').should.deep.equal(['a_rel', 'b_rel', 'c_rel', 'd_rel']);
@@ -189,7 +192,7 @@ describe('Halacious Plugin', function () {
             }
         });
 
-        server.register({ register: halacious, options: { strict: true }}, function (err) {
+        server.register({ register: halacious, options: { strict: true } }, function (err) {
             if (err) return done(err);
             server.plugins.halacious.namespaces.add({ dir: __dirname + '/rels/mycompany', prefix: 'mco' });
             server.inject({
@@ -220,7 +223,7 @@ describe('Halacious Plugin', function () {
     });
 
     it('should route rel documentation', function (done) {
-        var server = new hapi.Server({ debug: { log: ['error']}});
+        var server = new hapi.Server({ debug: { log: ['error'] } });
         server.connection();
         server.register(vision, function (err) {
             if (err) done(err);
@@ -228,10 +231,10 @@ describe('Halacious Plugin', function () {
 
         server.register(halacious, function (err) {
             if (err) return done(err);
-            server.plugins.halacious.namespaces.add({dir: __dirname + '/rels/mycompany', prefix: 'mco'});
+            server.plugins.halacious.namespaces.add({ dir: __dirname + '/rels/mycompany', prefix: 'mco' });
         });
 
-        server.start(function(err) {
+        server.start(function (err) {
             if (err) return done(err);
 
             server.inject({
@@ -266,7 +269,7 @@ describe('Halacious Plugin', function () {
 
         server.register(halacious, function (err) {
             if (err) return done(err);
-            var path = server.plugins.halacious.route('test-route', {a: 'i', b: 'aint', c: 'fack'});
+            var path = server.plugins.halacious.route('test-route', { a: 'i', b: 'aint', c: 'fack' });
             path.should.equal('/i/aint/fack');
             done();
         });
@@ -321,10 +324,51 @@ describe('Halacious Plugin', function () {
 
         server.register(halacious, function (err) {
             if (err) return done(err);
-            server.plugins.halacious.route.bind(halacious, 'deez-treez', { foo: 'are', bar: 'fire/proof', things: { should: 'not break' } }).should.not.throw;
-            var path = server.plugins.halacious.route('deez-treez', { foo: 'are', bar: 'fire/proof', things: { should: 'not break' } });
+            server.plugins.halacious.route.bind(halacious, 'deez-treez', {
+                foo: 'are',
+                bar: 'fire/proof',
+                things: { should: 'not break' }
+            }).should.not.throw;
+            var path = server.plugins.halacious.route('deez-treez', {
+                foo: 'are',
+                bar: 'fire/proof',
+                things: { should: 'not break' }
+            });
             path.should.not.equal('/deez/treez/are/fire/proof');
             path.should.equal('/deez/treez/are/fire%2Fproof');
+            done();
+        });
+    });
+
+    it('should handle optional Hapi route parameters in a named route', function (done) {
+        var server = new hapi.Server();
+        server.connection({ port: 9090 });
+
+        server.route({
+            method: 'get',
+            path: '/deez/treez/{are?}',
+            config: {
+                handler: function (req, reply) {
+                    reply({ foo: req.params.foo });
+                },
+                plugins: {
+                    hal: {
+                        name: 'deez-treez'
+                    }
+                }
+            }
+        });
+
+        server.register(halacious, function (err) {
+            if (err) return done(err);
+
+            var path = null;
+            var fn = function () {
+                path = server.plugins.halacious.route('deez-treez', { are: 'fireproof' });
+            };
+            fn.should.not.throw(Error);
+            should.exist(path);
+            path.should.equal('/deez/treez/fireproof');
             done();
         });
     });
@@ -440,7 +484,7 @@ describe('Halacious Plugin', function () {
                 },
                 plugins: {
                     hal: {
-                        prepare: function(rep, done) {
+                        prepare: function (rep, done) {
                             rep.link('mco:boss', 'http://www.whitehouse.gov');
                             done();
                         }
@@ -489,7 +533,7 @@ describe('Halacious Plugin', function () {
                     reply({ firstName: 'Bob', lastName: 'Smith', bossId: '1234' });
                 },
                 plugins: {
-                    hal: function(rep, done) {
+                    hal: function (rep, done) {
                         rep.link('mco:boss', 'http://www.whitehouse.gov');
                         done();
                     }
@@ -534,7 +578,7 @@ describe('Halacious Plugin', function () {
             path: '/people/{id}',
             config: {
                 handler: function (req, reply) {
-                    reply({ firstName: 'Bob', lastName: 'Smith', boss: { firstName: 'Boss', lastName: 'Man'} });
+                    reply({ firstName: 'Bob', lastName: 'Smith', boss: { firstName: 'Boss', lastName: 'Man' } });
                 },
                 plugins: {
                     hal: {
@@ -571,7 +615,7 @@ describe('Halacious Plugin', function () {
                 lastName: 'Smith',
                 _embedded: {
                     'mco:boss': {
-                        _links: { self: { href: '/people/100/boss'} },
+                        _links: { self: { href: '/people/100/boss' } },
                         firstName: 'Boss',
                         lastName: 'Man'
                     }
@@ -591,7 +635,12 @@ describe('Halacious Plugin', function () {
             path: '/people/{id}',
             config: {
                 handler: function (req, reply) {
-                    reply({ id: 100, firstName: 'Bob', lastName: 'Smith', boss: { id: 200, firstName: 'Boss', lastName: 'Man'} });
+                    reply({
+                        id: 100,
+                        firstName: 'Bob',
+                        lastName: 'Smith',
+                        boss: { id: 200, firstName: 'Boss', lastName: 'Man' }
+                    });
                 },
                 plugins: {
                     hal: {
@@ -629,7 +678,7 @@ describe('Halacious Plugin', function () {
                 lastName: 'Smith',
                 _embedded: {
                     'mco:boss': {
-                        _links: { self: { href: '/people/100/200'} },
+                        _links: { self: { href: '/people/100/200' } },
                         id: 200,
                         firstName: 'Boss',
                         lastName: 'Man'
@@ -656,7 +705,7 @@ describe('Halacious Plugin', function () {
                         total: 2,
                         items: [
                             { id: 100, firstName: 'Bob', lastName: 'Smith' },
-                            { id: 200, firstName: 'Boss', lastName: 'Man'}
+                            { id: 200, firstName: 'Boss', lastName: 'Man' }
                         ]
                     });
                 },
@@ -700,13 +749,13 @@ describe('Halacious Plugin', function () {
                 _embedded: {
                     'mco:person': [
                         {
-                            _links: { self: { href: '/people/100' }, 'mco:boss': { href: '/people/100/boss'}},
+                            _links: { self: { href: '/people/100' }, 'mco:boss': { href: '/people/100/boss' } },
                             id: 100,
                             firstName: 'Bob',
                             lastName: 'Smith'
                         },
                         {
-                            _links: { self: { href: '/people/200' }, 'mco:boss': { href: '/people/200/boss'}},
+                            _links: { self: { href: '/people/200' }, 'mco:boss': { href: '/people/200/boss' } },
                             id: 200,
                             firstName: 'Boss',
                             lastName: 'Man'
@@ -731,7 +780,7 @@ describe('Halacious Plugin', function () {
                         firstName: 'Bob',
                         lastName: 'Smith',
                         bossId: '1234',
-                        toHal: function(rep, done) {
+                        toHal: function (rep, done) {
                             rep.link('mco:boss', './boss');
                             done();
                         }
@@ -766,7 +815,7 @@ describe('Halacious Plugin', function () {
             done();
         });
     });
-    
+
     it('should allow for programmatic population of a hal entity and it\'s configured embedded entities', function (done) {
         var server = new hapi.Server();
         server.connection({ port: 9090 });
@@ -777,20 +826,20 @@ describe('Halacious Plugin', function () {
             path: '/people/{id}',
             config: {
                 handler: function (req, reply) {
-                    reply({ firstName: 'Bob', lastName: 'Smith', bossId: '1234', foo: {id: '5678'}});
+                    reply({ firstName: 'Bob', lastName: 'Smith', bossId: '1234', foo: { id: '5678' } });
                 },
                 plugins: {
                     hal: {
-                        prepare: function(rep, done) {
+                        prepare: function (rep, done) {
                             rep.link('mco:boss', 'http://www.whitehouse.gov');
                             done();
                         },
                         embedded: {
-                            'foo' : {
+                            'foo': {
                                 path: 'foo',
                                 href: '/foo/{item.id}',
-                                prepare: function(rep, next) {
-                                    setTimeout(function() {
+                                prepare: function (rep, next) {
+                                    setTimeout(function () {
                                         rep.link('foo:bar', 'http://www.foo.com');
                                         next();
                                     }, 500);
@@ -837,7 +886,7 @@ describe('Halacious Plugin', function () {
             done();
         });
     });
-    
+
     it('should omit missing configured embedded entities', function (done) {
         var server = new hapi.Server();
         server.connection({ port: 9090 });
@@ -848,24 +897,24 @@ describe('Halacious Plugin', function () {
             path: '/people/{id}',
             config: {
                 handler: function (req, reply) {
-                    reply({ firstName: 'Bob', lastName: 'Smith', bossId: '1234', foo: {id: '5678'}});
+                    reply({ firstName: 'Bob', lastName: 'Smith', bossId: '1234', foo: { id: '5678' } });
                 },
                 plugins: {
                     hal: {
-                        prepare: function(rep, done) {
+                        prepare: function (rep, done) {
                             rep.link('mco:boss', 'http://www.whitehouse.gov');
                             done();
                         },
                         embedded: {
-                            'foo' : {
+                            'foo': {
                                 path: 'foo',
                                 href: '/foo/{item.id}',
-                                prepare: function(rep, next) {
+                                prepare: function (rep, next) {
                                     rep.link('foo:bar', 'http://www.foo.com');
                                     next();
                                 }
                             },
-                            'bar' : {
+                            'bar': {
                                 path: 'notthere',
                                 href: '/bar/{item.id}'
                             }
@@ -921,19 +970,19 @@ describe('Halacious Plugin', function () {
             path: '/people/{id}',
             config: {
                 handler: function (req, reply) {
-                    reply({ firstName: 'Bob', lastName: 'Smith', bossId: '1234', foo: [{id: '5678'}]});
+                    reply({ firstName: 'Bob', lastName: 'Smith', bossId: '1234', foo: [{ id: '5678' }] });
                 },
                 plugins: {
                     hal: {
-                        prepare: function(rep, done) {
+                        prepare: function (rep, done) {
                             rep.link('mco:boss', 'http://www.whitehouse.gov');
                             done();
                         },
                         embedded: {
-                            'foo' : {
+                            'foo': {
                                 path: 'foo',
                                 href: '/foo/{item.id}',
-                                prepare: function(rep, next) {
+                                prepare: function (rep, next) {
                                     rep.link('foo:bar', 'http://www.foo.com');
                                     next();
                                 }
@@ -1039,7 +1088,7 @@ describe('Halacious Plugin', function () {
         });
 
         server.register({
-            register:halacious,
+            register: halacious,
             options: {
                 absolute: true
             }
@@ -1078,7 +1127,10 @@ describe('Halacious Plugin', function () {
             }
         });
 
-        server.register({ register: halacious, options: { mediaTypes: ['application/json', 'application/hal+json']}}, function (err) {
+        server.register({
+            register: halacious,
+            options: { mediaTypes: ['application/json', 'application/hal+json'] }
+        }, function (err) {
             if (err) return done(err);
         });
 
@@ -1129,7 +1181,7 @@ describe('Halacious Plugin', function () {
             path: '/people',
             config: {
                 handler: function (req, reply) {
-                    reply({ items: [{ id: 100, firstName: 'Louis', lastName: 'CK' }]});
+                    reply({ items: [{ id: 100, firstName: 'Louis', lastName: 'CK' }] });
                 },
                 plugins: {
                     hal: {
@@ -1145,7 +1197,10 @@ describe('Halacious Plugin', function () {
             }
         });
 
-        server.register({ register: halacious, options: { mediaTypes: ['application/json', 'application/hal+json']}}, function (err) {
+        server.register({
+            register: halacious,
+            options: { mediaTypes: ['application/json', 'application/hal+json'] }
+        }, function (err) {
             if (err) return done(err);
         });
 
@@ -1153,18 +1208,18 @@ describe('Halacious Plugin', function () {
         server.inject({
             method: 'get',
             url: '/people?q=funny&start=1&token=12345',
-            headers: { Accept: 'application/hal+json'}
+            headers: { Accept: 'application/hal+json' }
         }, function (res) {
             res.statusCode.should.equal(200);
             result = JSON.parse(res.payload);
             result.should.deep.equal({
                 _links: {
-                        self: { href: '/people?q=funny&start=1' }
+                    self: { href: '/people?q=funny&start=1' }
                 },
                 _embedded: {
                     items: [
                         {
-                            _links: { self: { href: '/people/100' }},
+                            _links: { self: { href: '/people/100' } },
                             id: 100,
                             firstName: 'Louis',
                             lastName: 'CK'
@@ -1191,7 +1246,10 @@ describe('Halacious Plugin', function () {
             }
         });
 
-        server.register({ register: halacious, options: { mediaTypes: ['application/json', 'application/hal+json']}}, function (err) {
+        server.register({
+            register: halacious,
+            options: { mediaTypes: ['application/json', 'application/hal+json'] }
+        }, function (err) {
             if (err) return done(err);
         });
 
@@ -1199,7 +1257,7 @@ describe('Halacious Plugin', function () {
         server.inject({
             method: 'post',
             url: '/api/people',
-            headers: { Accept: 'application/hal+json'}
+            headers: { Accept: 'application/hal+json' }
         }, function (res) {
             try {
                 res.statusCode.should.equal(201);
@@ -1234,7 +1292,10 @@ describe('Halacious Plugin', function () {
             }
         });
 
-        server.register({ register: halacious, options: { mediaTypes: ['application/json', 'application/hal+json']}}, function (err) {
+        server.register({
+            register: halacious,
+            options: { mediaTypes: ['application/json', 'application/hal+json'] }
+        }, function (err) {
             if (err) return done(err);
         });
 
@@ -1242,7 +1303,7 @@ describe('Halacious Plugin', function () {
         server.inject({
             method: 'get',
             url: '/api/people/100',
-            headers: { Accept: 'application/hal+json'}
+            headers: { Accept: 'application/hal+json' }
         }, function (res) {
             try {
                 res.statusCode.should.equal(200);
@@ -1276,14 +1337,17 @@ describe('Halacious Plugin', function () {
                 }
             });
 
-            server.register({ register: halacious, options: { mediaTypes: ['application/json', 'application/hal+json']}}, function (err) {
+            server.register({
+                register: halacious,
+                options: { mediaTypes: ['application/json', 'application/hal+json'] }
+            }, function (err) {
                 if (err) return done(err);
             });
 
             server.inject({
                 method: 'get',
                 url: 'http://localhost:9090/api/people/100',
-                headers: { Accept: 'application/hal+json'}
+                headers: { Accept: 'application/hal+json' }
             }, function (res) {
                 var result = JSON.parse(res.payload);
                 result._links.self.should.have.property('href', 'http://localhost:9090/api/people/100');
@@ -1313,14 +1377,17 @@ describe('Halacious Plugin', function () {
                 }
             });
 
-            server.register({ register: halacious, options: { mediaTypes: ['application/json', 'application/hal+json']}}, function (err) {
+            server.register({
+                register: halacious,
+                options: { mediaTypes: ['application/json', 'application/hal+json'] }
+            }, function (err) {
                 if (err) return done(err);
             });
 
             server.inject({
                 method: 'get',
                 url: 'http://localhost:9090/api/people/100',
-                headers: { Accept: 'application/hal+json'}
+                headers: { Accept: 'application/hal+json' }
             }, function (res) {
                 var result = JSON.parse(res.payload);
                 result._links.schedule.should.have.property('href', 'http://localhost:9090/api/people/100/schedule');
@@ -1337,7 +1404,7 @@ describe('Halacious Plugin', function () {
                 path: '/api/people/100',
                 config: {
                     handler: function (req, reply) {
-                        reply({ firstName: 'Bob', lastName: 'Smith', boss: { firstName: 'Boss', lastName: 'Man'} });
+                        reply({ firstName: 'Bob', lastName: 'Smith', boss: { firstName: 'Boss', lastName: 'Man' } });
                     },
                     plugins: {
                         hal: {
@@ -1353,14 +1420,17 @@ describe('Halacious Plugin', function () {
                 }
             });
 
-            server.register({ register: halacious, options: { mediaTypes: ['application/json', 'application/hal+json']}}, function (err) {
+            server.register({
+                register: halacious,
+                options: { mediaTypes: ['application/json', 'application/hal+json'] }
+            }, function (err) {
                 if (err) return done(err);
             });
 
             server.inject({
                 method: 'get',
                 url: 'http://localhost:9090/api/people/100',
-                headers: { Accept: 'application/hal+json'}
+                headers: { Accept: 'application/hal+json' }
             }, function (res) {
                 var result = JSON.parse(res.payload);
                 result._embedded['mco:boss']._links.self.should.have.property('href', 'http://localhost:9090/api/people/100/boss');
@@ -1387,14 +1457,17 @@ describe('Halacious Plugin', function () {
                 }
             });
 
-            server.register({ register: halacious, options: { mediaTypes: ['application/json', 'application/hal+json']}}, function (err) {
+            server.register({
+                register: halacious,
+                options: { mediaTypes: ['application/json', 'application/hal+json'] }
+            }, function (err) {
                 if (err) return done(err);
             });
 
             server.inject({
                 method: 'post',
                 url: 'http://localhost:9090/api/people',
-                headers: { Accept: 'application/hal+json'}
+                headers: { Accept: 'application/hal+json' }
             }, function (res) {
                 var result = JSON.parse(res.payload);
                 result._links.self.should.have.property('href', 'http://localhost:9090/api/people/100');
@@ -1427,7 +1500,7 @@ describe('Halacious Plugin', function () {
         server.route({
             method: 'get',
             path: '/people',
-            handler: function(req, reply) {
+            handler: function (req, reply) {
                 reply({
                     items: [{ id: 100 }, { id: 200 }]
                 });
@@ -1438,7 +1511,7 @@ describe('Halacious Plugin', function () {
                         embedded: {
                             'mco:person': {
                                 path: 'items',
-                                href: function(rep, ctx) {
+                                href: function (rep, ctx) {
                                     return rep.route('person', { id: ctx.item.id });
                                 }
                             }
@@ -1504,7 +1577,7 @@ describe('Halacious Plugin', function () {
                     hal: {
                         query: '{?full}',
                         links: {
-                            'mco:boss': function(rep, entity) {
+                            'mco:boss': function (rep, entity) {
                                 return rep.route('person', { id: entity.bossId });
                             }
                         }
@@ -1563,7 +1636,7 @@ describe('Halacious Plugin', function () {
             }
         });
 
-        server.register({ register: halacious, options: { absolute: true }}, function (err) {
+        server.register({ register: halacious, options: { absolute: true } }, function (err) {
             if (err) return done(err);
 
             server.plugins.halacious.namespaces
@@ -1579,7 +1652,7 @@ describe('Halacious Plugin', function () {
             result.should.deep.equal({
                 _links: {
                     curies: [{ name: 'mco', href: '/rels/mycompany/{rel}', templated: true }],
-                    self: { href: server.info.uri + '/api/'},
+                    self: { href: server.info.uri + '/api/' },
                     'mco:people': { href: server.info.uri + '/people{?full}', templated: true }
                 }
             });
@@ -1614,7 +1687,7 @@ describe('Halacious Plugin', function () {
             }
         });
 
-        server.register({ register: halacious, options: { absolute: true }}, function (err) {
+        server.register({ register: halacious, options: { absolute: true } }, function (err) {
             if (err) return done(err);
 
             server.plugins.halacious.namespaces
@@ -1630,7 +1703,7 @@ describe('Halacious Plugin', function () {
             result.should.deep.equal({
                 _links: {
                     curies: [{ name: 'mco', href: '/rels/mycompany/{rel}', templated: true }],
-                    self: { href: server.info.uri + '/people'}
+                    self: { href: server.info.uri + '/people' }
                 },
                 _embedded: {
                     'mco:person': []
@@ -1656,7 +1729,7 @@ describe('Halacious Plugin', function () {
             }
         });
 
-        server.register({ register: halacious, options: { absolute: true }}, function (err) {
+        server.register({ register: halacious, options: { absolute: true } }, function (err) {
             if (err) return done(err);
         });
 
@@ -1690,7 +1763,7 @@ describe('Halacious Plugin', function () {
             }
         });
 
-        server.register({ register: halacious, options: { absolute: true }}, function (err) {
+        server.register({ register: halacious, options: { absolute: true } }, function (err) {
             if (err) return done(err);
         });
 
@@ -1721,7 +1794,7 @@ describe('Halacious Plugin', function () {
             }
         });
 
-        server.register({ register: halacious, options: { absolute: true }}, function (err) {
+        server.register({ register: halacious, options: { absolute: true } }, function (err) {
             if (err) return done(err);
         });
 
@@ -1760,7 +1833,7 @@ describe('Halacious Plugin', function () {
             }
         });
 
-        server.register({ register: halacious, options: { absolute: true, protocol: 'https' }}, function (err) {
+        server.register({ register: halacious, options: { absolute: true, protocol: 'https' } }, function (err) {
             if (err) return done(err);
         });
 
@@ -1793,7 +1866,7 @@ describe('Halacious Plugin', function () {
             }
         });
 
-        server.register({ register: halacious, options: { absolute: true, host: 'www.cloud.com' }}, function (err) {
+        server.register({ register: halacious, options: { absolute: true, host: 'www.cloud.com' } }, function (err) {
             if (err) return done(err);
         });
 
@@ -1827,7 +1900,7 @@ describe('Halacious Plugin', function () {
             }
         });
 
-        server.register({ register: halacious, options: { absolute: true }}, function (err) {
+        server.register({ register: halacious, options: { absolute: true } }, function (err) {
             if (err) return done(err);
         });
 
@@ -1869,9 +1942,11 @@ describe('Halacious Plugin', function () {
             }
         });
 
-        server.register({ register: halacious, options: {
-            requireHalJsonAcceptHeader: true
-        }}, function (err) {
+        server.register({
+            register: halacious, options: {
+                requireHalJsonAcceptHeader: true
+            }
+        }, function (err) {
             if (err) return done(err);
         });
 
@@ -1939,9 +2014,11 @@ describe('Halacious Plugin', function () {
             }
         });
 
-        server.register({ register: halacious, options: {
-            requireHalJsonAcceptHeader: true
-        }}, function (err) {
+        server.register({
+            register: halacious, options: {
+                requireHalJsonAcceptHeader: true
+            }
+        }, function (err) {
             if (err) return done(err);
         });
 
@@ -1955,7 +2032,7 @@ describe('Halacious Plugin', function () {
             res.headers['content-type'].should.contain('application/hal+json');
             result = JSON.parse(res.payload);
             result.should.deep.equal({
-                _links: { self: { href: '/people/100'}},
+                _links: { self: { href: '/people/100' } },
                 firstName: 'Bob',
                 lastName: 'Smith'
             });


### PR DESCRIPTION
rep.route('some-route-name', {params: ''}) would throw when the named route's path had parameter modifiers