### PR TITLE
Links relative to the server root are also relative.

### DIFF
--- a/lib/plugin.js
+++ b/lib/plugin.js
@@ -373,7 +373,11 @@ exports.register = function (server, opts, next) {
     };
 
     internals.isRelativePath = function (path) {
-        return path && (path.substring(0, 2) === './' || path.substring(0, 3) === '../');
+        return path && (
+            path.substring(0, 2) === './' ||
+            path.substring(0, 3) === '../' ||
+            path.substring(0, 1) === '/'
+        );
     };
 
     /**


### PR DESCRIPTION
When configuring links that are relative to the root of the webserver in combination with the `absolute=true` plugin option causes non-absolute links to be generated.

I think the problem lies in the `isRelativePath` check, which should also consider paths relative to the server root as relative.

Example:

```
server.register({
    register: require('halacious'),
    options: { absolute: true }
})
.then(() => {
    server.route({
        method: 'GET',
        path: '/items',
        handler: function(req, reply) { reply({}); },
        config: {
            plugins: {
                hal: {
                    links: {
                        keys: '/keys',
                        values: '/values'
                    }
                }
            }
        }
    });
})
.then(() => {
    server.start();
})
```

Will currently return the following, note that the `href` for `keys` and `values` are not absolute.

```
{
  "_links": {
    "self": {
      "href": "http://localhost:5000/items"
    },
    "keys": {
      "href": "/keys"
    },
    "values": {
      "href": "/values"
    }
  }
}
```