### PR TITLE
Replace onPreResponse hook with onPostHandler

### DIFF
--- a/lib/plugin.js
+++ b/lib/plugin.js
@@ -795,7 +795,7 @@ exports.register = function (server, opts, next) {
      * @param request
      * @param reply
      */
-    internals.preResponse = function (request, reply) {
+    internals.postHandler = function (request, reply) {
         var rf, halConfig, entity, rep, self, location;
         var mediaType = internals.getMediaType(settings.mediaTypes, request);
         var absolute;
@@ -824,7 +824,7 @@ exports.register = function (server, opts, next) {
                 }
 
                 // send back what they asked for
-                request.response.source = rep
+                request.response.source = rep.toJSON();
                 request.response.type(mediaType)
 
                 reply.continue()
@@ -837,7 +837,7 @@ exports.register = function (server, opts, next) {
     // hapi wont find the local swig without this
     server.expose(api);
 
-    selection.ext('onPreResponse', internals.preResponse);
+    selection.ext('onPostHandler', internals.postHandler);
 
     if (settings.autoApi) {
         // bind the API handler to api root + '/'. Ending with '/' is necessary for resolving relative links on the client

--- a/lib/plugin.js
+++ b/lib/plugin.js
@@ -823,7 +823,8 @@ exports.register = function (server, opts, next) {
                     return reply(err);
                 }
 
-                // send back what they asked for
+                // send back what they asked for, as plain object
+                // so validation can be done correctly
                 request.response.source = rep.toJSON();
                 request.response.type(mediaType)
 

--- a/lib/representation.js
+++ b/lib/representation.js
@@ -96,8 +96,27 @@ Representation.prototype.toJSON = function() {
 
     // merge in any extra properties
     _.assign(payload, this._props);
-    if (_.keys(this._embedded).length > 0) {
-        payload._embedded = this._embedded;
+
+    const embeddedKeys = _.keys(this._embedded);
+    if (embeddedKeys.length > 0) {
+        payload._embedded = {};
+
+        const self = this;
+        embeddedKeys.forEach(function (embedKey) {
+            if (self._embedded[embedKey] instanceof Representation) {
+                payload._embedded[embedKey] = {};
+            } else if (self._embedded[embedKey] instanceof Array) {
+                payload._embedded[embedKey] = [];
+            }
+
+            JSON.stringify(self._embedded[embedKey], function (key, value) {
+                if (!key) {
+                    return value;
+                }
+
+                payload._embedded[embedKey][key] = value;
+            });
+        });
     }
 
     return payload;
@@ -122,7 +141,7 @@ Representation.prototype.link = function(rel, link) {
             return that.link(originalRel, l);
         }, this);
     }
-    
+
     // adds the namespace to the top level curie list
     this.curie(rel.namespace);
 

--- a/test/plugin-spec.js
+++ b/test/plugin-spec.js
@@ -2060,7 +2060,7 @@ describe('Halacious Plugin', function () {
 
         var anotherPlugin = {
             register: function (server, options, next) {
-                server.ext('onPreResponse', function(request, reply) {
+                server.ext('onPostHandler', function(request, reply) {
                     callback()
                     reply.continue()
                 })

--- a/test/representation-spec.js
+++ b/test/representation-spec.js
@@ -47,7 +47,7 @@ describe('Representation Factory', function() {
         rep._links['mco:boss'][1].should.have.property('href', '/people/101');
         rep._links['mco:boss'][2].should.have.property('href', '/people/102');
     });
-    
+
     it('should create a single-element array of links', function () {
         var entity = {};
         var rep = rf.create(entity, '/people');
@@ -117,6 +117,53 @@ describe('Representation Factory', function() {
         var rep = rf.create(entity, '/me');
         var json = JSON.stringify(rep);
         json.should.deep.equal('{"_links":{"self":{"href":"/me"}},"id":100,"name":"John Smith","company":"Acme","boss":{"id":100,"name":"Boss Man","company":"Acme"}}');
+    });
+
+    it('should handle direct call toJSON correctly', function () {
+        var entity = {
+            _id: 100,
+            _hidden: 'hidden',
+            name: 'John Smith',
+            company: 'Acme',
+            toJSON: function () {
+                return {
+                    id: this._id,
+                    name: this.name,
+                    company: this.company,
+                }
+            },
+        };
+
+        var rep = rf.create(entity, '/me');
+        rep.embed('mco:boss', './boss', [{
+            _id: 100,
+            _hidden: 'hidden',
+            name: 'Boss Man',
+            company: 'Acme',
+            toJSON: function () {
+                return {
+                    id: this._id,
+                    name: this.name,
+                    company: this.company
+                }
+            }
+        }]);
+        rep.embed('mco:boss2', './boss2', {
+            _id: 100,
+            _hidden: 'hidden',
+            name: 'Boss Man',
+            company: 'Acme',
+            toJSON: function () {
+                return {
+                    id: this._id,
+                    name: this.name,
+                    company: this.company
+                }
+            }
+        })
+
+        var json = rep.toJSON();
+        json.should.deep.equal({"_links":{"self":{"href":"/me"}},"id":100,"name":"John Smith","company":"Acme","_embedded":{"mco:boss":[{"_links":{"self":{"href":"/me/boss"}},"id":100,"name":"Boss Man","company":"Acme"}],"mco:boss2":{"_links":{"self":{"href":"/me/boss2"}},"id":100,"name":"Boss Man","company":"Acme"}}});
     });
 
     it('should link to a registered rel', function () {

--- a/test/representation-spec.js
+++ b/test/representation-spec.js
@@ -134,33 +134,27 @@ describe('Representation Factory', function() {
             },
         };
 
+        var boss = {
+            _id: 100,
+            _hidden: 'hidden',
+            name: 'Boss Man',
+            company: 'Acme',
+            toJSON: function () {
+                return {
+                    id: this._id,
+                    name: this.name,
+                    company: this.company
+                }
+            }
+        };
+
         var rep = rf.create(entity, '/me');
-        rep.embed('mco:boss', './boss', [{
-            _id: 100,
-            _hidden: 'hidden',
-            name: 'Boss Man',
-            company: 'Acme',
-            toJSON: function () {
-                return {
-                    id: this._id,
-                    name: this.name,
-                    company: this.company
-                }
-            }
-        }]);
-        rep.embed('mco:boss2', './boss2', {
-            _id: 100,
-            _hidden: 'hidden',
-            name: 'Boss Man',
-            company: 'Acme',
-            toJSON: function () {
-                return {
-                    id: this._id,
-                    name: this.name,
-                    company: this.company
-                }
-            }
-        })
+
+        // Should embed array of objects correctly
+        rep.embed('mco:boss', './boss', [boss]);
+
+        // Should embed single object correctly
+        rep.embed('mco:boss2', './boss2', boss)
 
         var json = rep.toJSON();
         json.should.deep.equal({"_links":{"self":{"href":"/me"}},"id":100,"name":"John Smith","company":"Acme","_embedded":{"mco:boss":[{"_links":{"self":{"href":"/me/boss"}},"id":100,"name":"Boss Man","company":"Acme"}],"mco:boss2":{"_links":{"self":{"href":"/me/boss2"}},"id":100,"name":"Boss Man","company":"Acme"}}});


### PR DESCRIPTION
Also fixed so you can call .toJSON() on a representation and get back an object that is prepared for JSON format.