### PR TITLE
Cache route templates to fix memory leak and increase speed

### DIFF
--- a/lib/plugin.js
+++ b/lib/plugin.js
@@ -423,6 +423,8 @@ exports.register = function (server, opts, next) {
         }
     };
 
+    internals.routeTemplateCache = {};
+
     /**
      * Locates a named route and expands templated parameters
      * @param routeId
@@ -432,7 +434,14 @@ exports.register = function (server, opts, next) {
     internals.route = function (routeId, params) {
         var route = server.lookup(routeId) || internals.locateRoute(routeId);
         if (!route) throw new Error('No route found with id or name ' + routeId);
-        var href = internals.buildUrl(undefined, _.template(route.path, { interpolate: /{([\s\S]+?)(?:\?|\*\d*)??}/g })(_.mapValues(params, function(val) {
+
+        var routeTpl = internals.routeTemplateCache[route.path];
+        if (!routeTpl) {
+            routeTpl = _.template(route.path, { interpolate: /{([\s\S]+?)(?:\?|\*\d*)??}/g });
+            internals.routeTemplateCache[route.path] = routeTpl;
+        }
+
+        var href = internals.buildUrl(undefined, routeTpl(_.mapValues(params, function(val) {
             return typeof val !== 'object' ? encodeURIComponent(val) : val;
         })));
         var query = hoek.reach(route.settings, 'plugins.hal.query');


### PR DESCRIPTION
Added a route template cache for compiled templates to `internals.route()` in `plugin.js` so that only one template is created for each route path. This fixes a memory leak where each call to `route()` would leak the compiled code for the template. Using a cache should also increase speed.